### PR TITLE
Ignore missing submodules

### DIFF
--- a/lib/sandboxed_module.js
+++ b/lib/sandboxed_module.js
@@ -169,12 +169,11 @@ SandboxedModule.prototype._createRecursiveRequireProxy = function() {
   cache[this.filename] = this.exports;
   var globals = this.globals;
 
-  var options;
+  var options = {};
   if(!this._options.sourceTransformersSingleOnly && this._options.sourceTransformers){
-    options = {
-      sourceTransformers: this._options.sourceTransformers
-    };
+    options.sourceTransformers = this._options.sourceTransformers;
   }
+  options.ignoreMissing = this._options.ignoreMissing;
 
   function createInnerSandboxedModule(requestedFilename){
       // load nested dependency in sandboxed module
@@ -214,11 +213,17 @@ SandboxedModule.prototype._createRecursiveRequireProxy = function() {
       if (request in cache) return cache[request];
       return require(request);
     }
+
     // cached modules
-    var requestedFilename = requireLike(this.filename).resolve(request);
-    if (requestedFilename in cache) return cache[requestedFilename];
-    var sandboxedModule = createInnerSandboxedModule(requestedFilename)
-    return sandboxedModule.exports;
+    try {
+      var requestedFilename = requireLike(this.filename).resolve(request);
+      if (requestedFilename in cache) return cache[requestedFilename];
+      var sandboxedModule = createInnerSandboxedModule(requestedFilename)
+      return sandboxedModule.exports;
+    } catch (e) {
+      if (this._options.ignoreMissing && request in cache) return cache[request];
+      throw e;
+    }
   }
   return RecursiveRequireProxy.bind(this);
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,10 @@
   ],
   "license": "MIT",
   "version": "2.1.0",
-  "repository": "log4js-node/node-sandboxed-module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/log4js-node/node-sandboxed-module.git"
+  },
   "main": "./lib/sandboxed_module",
   "files": [
     "lib/"

--- a/test/fixture/loads-missing.js
+++ b/test/fixture/loads-missing.js
@@ -1,0 +1,3 @@
+exports.doesNotExist = require('doesNotExist');
+exports.alsoDoesNotExist = require('./alsoDoesNotExist');
+exports.subModule = require('./subModule');

--- a/test/fixture/subModule.js
+++ b/test/fixture/subModule.js
@@ -1,0 +1,1 @@
+exports.requiredFromSubModule = require('requiredFromSubModule');

--- a/test/integration/test-inject-missing.js
+++ b/test/integration/test-inject-missing.js
@@ -1,9 +1,14 @@
 var assert = require('assert');
 var SandboxedModule = require('../..');
 
-var foo = SandboxedModule.require('../fixture/foo', {
-	"requires": {"doesNotExist": {}},
+var foo = SandboxedModule.require('../fixture/loads-missing', {
+	"requires": {
+    "doesNotExist": { fake: true },
+    "./alsoDoesNotExist": { cheese: 'gouda' },
+    "requiredFromSubModule": { didItWork: 'yes' }
+  },
 	"ignoreMissing": true
 });
-assert.strictEqual(foo.foo, 'foo');
-assert.strictEqual(foo.bar, 'bar');
+assert.ok(foo.doesNotExist.fake);
+assert.strictEqual(foo.alsoDoesNotExist.cheese, 'gouda');
+assert.strictEqual(foo.subModule.requiredFromSubModule.didItWork, 'yes');


### PR DESCRIPTION
Handles injecting missing modules when required in modules that are required from sandboxed modules (see the test fixtures if that sentence makes no sense).